### PR TITLE
Add sidecar container to deployment/daemonset for insight into audit log file

### DIFF
--- a/docs/examples/modsecurity/index.html
+++ b/docs/examples/modsecurity/index.html
@@ -48,7 +48,7 @@ var doNotTrack = false;
 if (!doNotTrack) {
 	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 	ga('create', 'UA-150719229-1', 'auto');
-	
+
 	ga('send', 'pageview');
 }
 </script>
@@ -73,67 +73,67 @@ if (!doNotTrack) {
   </head>
   <body class="td-page">
     <header>
-      
+
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark flex-column flex-md-row td-navbar">
         <a class="navbar-brand" href="/">
 		<span class="navbar-logo"></span><span class="text-uppercase font-weight-bold">HAProxy Ingress</span>
 	</a>
 	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
 		<ul class="navbar-nav mt-2 mt-lg-0">
-			
-			
+
+
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
-				
-				
-				
-				
-				
-				
+
+
+
+
+
+
 				<a class="nav-link" href="/about/" ><span>About</span></a>
 			</li>
-			
+
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
-				
-				
-				
-				
-				
-				
+
+
+
+
+
+
 				<a class="nav-link active" href="/docs/" ><span class="active">Documentation</span></a>
 			</li>
-			
+
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
-				
-				
-				
-				
-				
-				
+
+
+
+
+
+
 				<a class="nav-link" href="/community/" ><span>Community</span></a>
 			</li>
-			
-			
+
+
 			<li class="nav-item dropdown d-none d-lg-block">
 				<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 	v0.12 (latest)
 </a>
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-	
+
 	<a class="dropdown-item" href="https://haproxy-ingress.github.io/v0.13/docs">v0.13 (beta)</a>
-	
+
 	<a class="dropdown-item" href="https://haproxy-ingress.github.io/docs">v0.12 (latest)</a>
-	
+
 	<a class="dropdown-item" href="https://haproxy-ingress.github.io/v0.11/docs">v0.11</a>
-	
+
 	<a class="dropdown-item" href="https://haproxy-ingress.github.io/v0.10/docs">v0.10</a>
-	
+
 	<a class="dropdown-item" href="https://haproxy-ingress.github.io/v0.9/docs">v0.9</a>
-	
+
 </div>
 
 			</li>
-			
-			
+
+
 		</ul>
 	</div>
 	<div class="navbar-nav d-none d-lg-block"></div>
@@ -144,22 +144,22 @@ if (!doNotTrack) {
       <div class="td-main">
         <div class="row flex-xl-nowrap">
           <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
-            
+
 
 
 
 
 <div id="td-sidebar-menu" class="td-sidebar__inner">
-  
+
   <form class="td-sidebar__search d-flex align-items-center">
-    
+
     <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>
-  
+
   <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
-    
-    
+
+
 
 
 
@@ -172,11 +172,11 @@ if (!doNotTrack) {
   </li>
   <ul>
     <li class="collapse show" id="docs">
-      
-      
-      
-      
-      
+
+
+
+
+
 
 
 
@@ -189,17 +189,17 @@ if (!doNotTrack) {
   </li>
   <ul>
     <li class="collapse " id="docs-overview">
-      
-      
-      
+
+
+
     </li>
   </ul>
 </ul>
 
-      
-      
-      
-      
+
+
+
+
 
 
 
@@ -212,17 +212,17 @@ if (!doNotTrack) {
   </li>
   <ul>
     <li class="collapse " id="docs-getting-started">
-      
-      
-      
+
+
+
     </li>
   </ul>
 </ul>
 
-      
-      
-      
-      
+
+
+
+
 
 
 
@@ -235,41 +235,41 @@ if (!doNotTrack) {
   </li>
   <ul>
     <li class="collapse show" id="docs-examples">
-      
-      
-      
-      
-      
-      
+
+
+
+
+
+
       <a class="td-sidebar-link td-sidebar-link__page " id="m-docs-examples-blue-green" href="/docs/examples/blue-green/">Blue/green</a>
-      
-      
-      
-      
-      
+
+
+
+
+
       <a class="td-sidebar-link td-sidebar-link__page " id="m-docs-examples-external-haproxy" href="/docs/examples/external-haproxy/">External haproxy</a>
-      
-      
-      
-      
-      
+
+
+
+
+
       <a class="td-sidebar-link td-sidebar-link__page " id="m-docs-examples-metrics" href="/docs/examples/metrics/">Metrics</a>
-      
-      
-      
-      
-      
+
+
+
+
+
       <a class="td-sidebar-link td-sidebar-link__page  active" id="m-docs-examples-modsecurity" href="/docs/examples/modsecurity/">ModSecurity</a>
-      
-      
+
+
     </li>
   </ul>
 </ul>
 
-      
-      
-      
-      
+
+
+
+
 
 
 
@@ -282,35 +282,35 @@ if (!doNotTrack) {
   </li>
   <ul>
     <li class="collapse " id="docs-configuration">
-      
-      
-      
-      
-      
-      
+
+
+
+
+
+
       <a class="td-sidebar-link td-sidebar-link__page " id="m-docs-configuration-keys" href="/docs/configuration/keys/">Keys</a>
-      
-      
-      
-      
-      
+
+
+
+
+
       <a class="td-sidebar-link td-sidebar-link__page " id="m-docs-configuration-command-line" href="/docs/configuration/command-line/">Command-line</a>
-      
-      
-      
-      
-      
+
+
+
+
+
       <a class="td-sidebar-link td-sidebar-link__page " id="m-docs-configuration-template" href="/docs/configuration/template/">Template</a>
-      
-      
+
+
     </li>
   </ul>
 </ul>
 
-      
-      
-      
-      
+
+
+
+
 
 
 
@@ -323,15 +323,15 @@ if (!doNotTrack) {
   </li>
   <ul>
     <li class="collapse " id="docs-contribution-guidelines">
-      
-      
-      
+
+
+
     </li>
   </ul>
 </ul>
 
-      
-      
+
+
     </li>
   </ul>
 </ul>
@@ -344,7 +344,7 @@ if (!doNotTrack) {
 
           </div>
           <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
-            
+
 
 
 
@@ -384,7 +384,7 @@ if (!doNotTrack) {
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             <nav aria-label="breadcrumb" class="d-none d-md-block d-print-none">
 	<ol class="breadcrumb spb-1">
-		
+
 
 
 
@@ -416,11 +416,11 @@ if (!doNotTrack) {
 	</ol>
 </nav	>
 
-            
+
 <div class="td-content">
 	<h1>ModSecurity</h1>
 	<div class="lead">Demonstrate how to configure ModSecurity web application firewall.</div>
-	
+
 
 <p>This example demonstrates how to configure ModSecurity
 web application firewall on HAProxy Ingress controller.</p>
@@ -553,7 +553,24 @@ unique_id &quot;&quot;]
 ...
 </code></pre>
 
-	
+<h2 id="test">Deploy ModSecurity Agent With a Sidecar Container for Audit Logs</h2>
+
+
+<p>A ModSecurity agent can be deployed with an additional sidecar container so you can have access to the logs stored in the audit log file. If you are using the default configuration of the ModSecurity agent, the logs written to the audit log specified are not reachable in the agent container's STDOUT. In order to read information written to that file, you must add a sidecar container to the method of deployment of the ModSecurity agent in Kubernetes</p>
+
+<p>Update the ModSecurity agent daemonset to have a sidecar container to read the audit log file to STDOUT:</p>
+
+<pre><code>$ kubectl create -f https://haproxy-ingress.github.io/resources/modsecurity-daemonset-auditlog-sidecar.yaml
+daemonset &quot;modsecurity-spoa&quot; configured
+</code></pre>
+
+<pre><code>$ kubectl -n ingress-controller get pod -lrun=modsecurity-spoa -owide
+NAME                     READY     STATUS    RESTARTS   AGE       IP               NODE
+modsecurity-spoa-pp6jz   2/2       Running   0          7s        192.168.100.99   192.168.100.99
+</code></pre>
+
+<p>Now the ModSecurity agent pods will have two containers to get logs from.</p>
+
 		<style>
   .feedback--answer {
     display: inline-block;
@@ -613,8 +630,8 @@ unique_id &quot;&quot;]
 </script>
 
 		<br />
-	
-	
+
+
 	<div class="text-muted mt-5 pt-3 border-top">Last modified July 10, 2020: <a  href="https://github.com/jcmoraisjr/haproxy-ingress/commit/2b3cc6701b27866acd9db35cbbd0c4de114aaec2">Update deprecated APIs docs (2b3cc670)</a>
 </div>
 </div>
@@ -623,65 +640,65 @@ unique_id &quot;&quot;]
           </main>
         </div>
       </div>
-      
+
 <footer class="bg-dark py-5 row d-print-none">
   <div class="container-fluid mx-sm-5">
     <div class="row">
       <div class="col-6 col-sm-2 text-xs-center order-sm-2">
-        
-        
-        
+
+
+
 <ul class="list-inline mb-0">
-  
+
   <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="Slack" aria-label="Slack">
     <a class="text-white" target="_blank" href="https://kubernetes.slack.com/channels/haproxy-ingress">
       <i class="fab fa-slack"></i>
     </a>
   </li>
-  
+
   <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="Users mailing list" aria-label="Users mailing list">
     <a class="text-white" target="_blank" href="https://groups.google.com/forum/#!forum/haproxy-ingress">
       <i class="fa fa-envelope"></i>
     </a>
   </li>
-  
+
   <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="Stack Overflow" aria-label="Stack Overflow">
     <a class="text-white" target="_blank" href="https://stackoverflow.com/questions/tagged/haproxy-ingress">
       <i class="fab fa-stack-overflow"></i>
     </a>
   </li>
-  
+
 </ul>
 
-        
-        
+
+
       </div>
       <div class="col-6 col-sm-2 text-right text-xs-center order-sm-3">
-        
-        
-        
+
+
+
 <ul class="list-inline mb-0">
-  
+
   <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="GitHub" aria-label="GitHub">
     <a class="text-white" target="_blank" href="https://github.com/jcmoraisjr/haproxy-ingress">
       <i class="fab fa-github"></i>
     </a>
   </li>
-  
+
 </ul>
 
-        
-        
+
+
       </div>
       <div class="col-12 col-sm-8 text-center py-2 order-sm-2">
-        
+
           <small class="text-white">Made with <div class="fa fa-heart"></div> & <div class="fa fa-coffee"></div> | &copy; 2021 The HAProxy Ingress Controller Authors</small>
-        
+
         <small class="text-white"> | Image by <a href="https://pixabay.com/users/TheDigitalArtist-202249/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=3866609" target="_blank">Pete Linforth</a> from <a href="https://pixabay.com/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=3866609" target="_blank">Pixabay</a></small>
-        
-	
+
+
 		<p class="mt-2"><a href="/about/">About</a></p>
-	
+
       </div>
     </div>
   </div>
@@ -689,7 +706,7 @@ unique_id &quot;&quot;]
 
 
     </div>
-    
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 

--- a/resources/modsecurity-daemonset-auditlog-sidecar.yaml
+++ b/resources/modsecurity-daemonset-auditlog-sidecar.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    run: modsecurity-spoa
+  name: modsecurity-spoa
+  namespace: ingress-controller
+spec:
+  selector:
+    matchLabels:
+      run: modsecurity-spoa
+  template:
+    metadata:
+      labels:
+        run: modsecurity-spoa
+    spec:
+      containers:
+      - name: modsecurity-spoa
+        image: quay.io/jcmoraisjr/modsecurity-spoa
+        args:
+        - -n
+        - "1"
+        ports:
+        - containerPort: 12345
+          hostPort: 12345
+          name: spop
+          protocol: TCP
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+      - name: audit-log
+        image: busybox
+        args: [/bin/sh, -c, 'tail -n+1 -f /var/log/modsec_audit.log']
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+      hostNetwork: true
+      nodeSelector:
+        waf: modsec
+  updateStrategy:
+    type: RollingUpdate

--- a/resources/modsecurity-daemonset-auditlog-sidecar.yaml
+++ b/resources/modsecurity-daemonset-auditlog-sidecar.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         run: modsecurity-spoa
     spec:
+      volumes:
+      - name: varlog
+        emptyDir: {}
       containers:
       - name: modsecurity-spoa
         image: quay.io/jcmoraisjr/modsecurity-spoa


### PR DESCRIPTION
In our customization of  the ModSecurity agent, we have certain rules triggered to write to the auditlog and ignore being printed to the modsecurity-spoa container STDOUT. From my research, there doesn't appear to be a way to configure ModSecurity to also print the audit log file to STDOUT, but that might be better anyways because it would make it harder to read a file being edited with two different log sources.

We need to view what's going into the audit log file through container STDOUT. When we created the daemonset, we added a sidecar container to print that file to STDOUT for further ingestion.

Even though it is simple, it is extremely useful if someone was to seperate the destinations of logs for different rules and actions.